### PR TITLE
Add cleanup cmd

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ build:
 	docker build -t tmp-$(notdir $(CURDIR)) .
 
 test: build
+	tests/test_cleanup.sh tmp-$(notdir $(CURDIR))
 	tests/test_clean.sh tmp-$(notdir $(CURDIR))
 	tests/test_list.sh tmp-$(notdir $(CURDIR))
 	tests/test_logs.sh tmp-$(notdir $(CURDIR))

--- a/cmds/cleanup
+++ b/cmds/cleanup
@@ -6,4 +6,4 @@ set -e
 echo MARK
 
 test -e /output/
-find output -depth -type d -empty -delete -not -path "output/"
+find output -depth -type d -ctime +1 -empty -not -path "output" -delete

--- a/cmds/cleanup
+++ b/cmds/cleanup
@@ -6,4 +6,4 @@ set -e
 echo MARK
 
 test -e /output/
-find output -depth -type d -empty -delete
+find output -depth -type d -empty -delete -not -path "output/"

--- a/cmds/cleanup
+++ b/cmds/cleanup
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+set -e
+
+# FIXME: to MARK output was captured by docker-py as it fails some times...
+echo MARK
+
+test -e /output/
+find output -depth -type d -empty -delete

--- a/tests/test_cleanup.sh
+++ b/tests/test_cleanup.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+cd $(dirname $0)
+cd ..
+. tests/common.sh
+
+setup
+
+mkdir -p tests/data/empty
+mkdir -p tests/data/almost/empty
+mkdir -p tests/data/cool/
+touch tests/data/cool/some.file
+touch tests/data/cool/some.file2
+
+OUTPUT=$(docker run --rm -v $(pwd)/tests/data:/output:rw $IMAGE cleanup)
+assert "$OUTPUT" $'MARK'
+test -f tests/data/cool/some.file
+test -f tests/data/cool/some.file2


### PR DESCRIPTION
Add command to cleanup empty directories from output
If empty directories are not cleaned and the scanner is deleted, the parser will continuously fail with `invalid scanner id` error